### PR TITLE
[FIX] Problemas codificación

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1309,7 +1309,9 @@ class Export(http.Controller):
                 continue
 
             id = prefix + (prefix and '/'or '') + field_name
-            name = parent_name + (parent_name and '/' or '') + field['string']
+            name = parent_name + (parent_name and '/' or ''
+            ) + openerp.tools.ustr(field.get('string', ''))
+
             record = {'id': id, 'string': name,
                       'value': id, 'children': False,
                       'field_type': field.get('type'),


### PR DESCRIPTION
El error se ha detectado en distintas bases de tatos y campos a la hora de exportar los campos.
Resulta que al mostrar los campos para mostrarlos y poderlos seleccionar va concatenando los strings de las relaciones añadiendo `'/'`, resulta en ciertas ocasiones a causa de los acentos esto estaba causando el siguiente error de codificación:
`UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 27: ordinal not in range(128)`