### PR TITLE
[FIX][15.0] Wrong view to inherit

### DIFF
--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -195,7 +195,7 @@
         <record id="view_task_form2_inherit_sale_timesheet" model="ir.ui.view">
             <field name="name">view.task.form2.inherit</field>
             <field name="model">project.task</field>
-            <field name="inherit_id" ref="project.view_task_form2"/>
+            <field name="inherit_id" ref="sale_project.view_sale_project_inherit_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='sale_line_id']" position="attributes">
                     <attribute name="context">{'with_remaining_hours': True, 'with_price_unit': True}</attribute>

--- a/doc/cla/corporate/aurestic.md
+++ b/doc/cla/corporate/aurestic.md
@@ -1,0 +1,16 @@
+Spain, 2023-05-12
+
+Aures Tic Consultors S.L agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Jose Zambudio jose@aurestic.es https://github.com/zamberjo
+
+List of contributors:
+
+Almudena De la Puente almudena@aurestic.es https://github.com/almumu
+Jordi Toledo jordi.toledo@aurestic.es https://github.com/JordiToledo


### PR DESCRIPTION
It is inheriting from a view that does not contain the `sale_line_id` field giving error on `portal` users.

I modify the inheriting view to depend on the one that adds the `sale_line_id` field.